### PR TITLE
KT-26012 IDE Crash Work Around via Java [DO NOT MERGE]

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "info.kunalsheth.units:plugin:4.0.6"
+        classpath "info.kunalsheth.units:plugin:4.0.6+kt26012"
     }
 }
 

--- a/demo/units-of-measure.gradle
+++ b/demo/units-of-measure.gradle
@@ -21,4 +21,5 @@ generateUnitsOfMeasure {
     ].toSet()
 }
 sourceSets.main.kotlin.srcDir generateUnitsOfMeasure.generatedSrcDir
+sourceSets.main.java.srcDir generateUnitsOfMeasure.generatedSrcDir
 compileKotlin.dependsOn(generateUnitsOfMeasure)

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -7,7 +7,7 @@ apply plugin: "kotlin-platform-jvm"
 
 allprojects {
     group "info.kunalsheth.units"
-    version "4.0.6"
+    version "4.0.6+kt26012"
     repositories.jcenter()
 }
 

--- a/plugin/src/main/kotlin/info/kunalsheth/units/GenerateUnitsOfMeasureTask.kt
+++ b/plugin/src/main/kotlin/info/kunalsheth/units/GenerateUnitsOfMeasureTask.kt
@@ -24,6 +24,11 @@ open class GenerateUnitsOfMeasureTask @Inject constructor(p: Project) : DefaultT
         val srcWriter = generatedSrc.printWriter()
         writeBase(srcWriter)
 
+        kt26012WorkAroundSrc.parentFile.mkdirs()
+        val kt26012WorkAroundWriter = kt26012WorkAroundSrc.printWriter()
+        writeKt26012WorkAround(kt26012WorkAroundWriter)
+        kt26012WorkAroundWriter.close()
+
         val allDimensions = (relationships.flatMap { listOf(it.a, it.b, it.result) } +
                 quantities.map(Quantity::dimension) +
                 unitsOfMeasure.map(UnitOfMeasure::dimension) +
@@ -67,6 +72,9 @@ open class GenerateUnitsOfMeasureTask @Inject constructor(p: Project) : DefaultT
 
     @OutputFile
     val generatedSrc = File(generatedSrcDir, "UnitsOfMeasure.kt")
+
+    @OutputFile
+    val kt26012WorkAroundSrc = File(generatedSrcDir, "info/kunalsheth/units/generated/QuanFBV.java")
 
 
     // for Groovy to Kotlin interop

--- a/plugin/src/main/resources/info/kunalsheth/units/generated/Base.kt
+++ b/plugin/src/main/resources/info/kunalsheth/units/generated/Base.kt
@@ -1,55 +1,46 @@
 package info.kunalsheth.units.generated
 
-import kotlin.math.abs
 import kotlin.math.sign
-import kotlin.jvm.JvmName
+import kotlin.math.abs
 
 /**
  * Created by kunal on 8/6/17.
  */
-typealias Quan<Q> = Quantity<Q, *, *>
+typealias Quan<Q> = QuanFBV<Q, *, *>
+typealias Quantity<Q, I, D> = QuanFBV<Q, I, D>
 
-@Suppress("FINITE_BOUNDS_VIOLATION", "UNCHECKED_CAST")
-interface Quantity<This, Integral, Derivative> : Comparable<Quan<This>> where
-This : Quantity<This, Integral, Derivative>,
-Integral : Quantity<Integral, *, This>,
-Derivative : Quantity<Derivative, This, *> {
-    val siValue: Double
-    val abrev: String
+val <Q : Quan<Q>> Quan<Q>.siValue get() = fbvSiValue()
+val <Q : Quan<Q>> Quan<Q>.abrev get() = fbvAbrev()
+fun <Q : Quan<Q>> Quan<Q>.new(siValue: Double) = fbvNew(siValue)
 
-    fun new(siValue: Double): This
+operator fun <Q : Quan<Q>> Q.unaryPlus() = this
+operator fun <Q : Quan<Q>> Q.unaryMinus() = new(-siValue)
 
-    operator fun unaryPlus(): This = this as This
-    operator fun unaryMinus(): This = new(-siValue)
+operator fun <Q : Quan<Q>> Quan<Q>.plus(that: Quan<Q>) = new(this.siValue + that.siValue)
+operator fun <Q : Quan<Q>> Quan<Q>.minus(that: Quan<Q>) = new(this.siValue - that.siValue)
+operator fun <Q : Quan<Q>> Quan<Q>.times(that: Number) = new(this.siValue * that.toDouble())
+operator fun <Q : Quan<Q>> Quan<Q>.div(that: Number) = new(this.siValue / that.toDouble())
+operator fun <Q : Quan<Q>> Quan<Q>.rem(that: Quan<Q>) = new(this.siValue % that.siValue)
 
-    operator fun plus(that: Quan<This>): This = new(this.siValue + that.siValue)
-    operator fun minus(that: Quan<This>): This = new(this.siValue - that.siValue)
-    operator fun times(that: Number): This = new(this.siValue * that.toDouble())
-    operator fun div(that: Number): This = new(this.siValue / that.toDouble())
-    operator fun rem(that: Quan<This>): This = new(this.siValue % that.siValue)
+operator fun <Q : Quantity<Q, IQ, *>, IQ> Q.times(that: Quan<T>) = fbvTimes(that)
+operator fun <Q : Quantity<Q, *, DQ>, DQ> Q.div(that: Quan<T>) = fbvDiv(that)
 
-    operator fun times(that: Quan<T>): Integral = TODO()
-    operator fun div(that: Quan<T>): Derivative = TODO()
-
-    @Suppress("UNCHECKED_CAST")
-    operator fun rangeTo(that: Quan<This>) = object : ClosedRange<This> {
-        override val start = (this@Quantity min that)
-        override val endInclusive = (this@Quantity max that)
-    }
-
-    infix fun min(that: Quan<This>): This = (if (this < that) this else that) as This
-    infix fun max(that: Quan<This>): This = (if (this > that) this else that) as This
-
-    val abs: This get() = new(abs(siValue))
-    val signum get() = siValue.sign
-    val isNegative: Boolean get() = siValue < 0
-    val isPositive: Boolean get() = siValue > 0
-
-    override fun compareTo(other: Quan<This>) = this.siValue.compareTo(other.siValue)
+@Suppress("UNCHECKED_CAST")
+operator fun <Q : Quan<Q>> Quan<Q>.rangeTo(that: Quan<Q>) = object : ClosedRange<Q> {
+    override val start = (this@rangeTo min that)
+    override val endInclusive = (this@rangeTo max that)
 }
 
+infix fun <Q : Quan<Q>> Quan<Q>.min(that: Quan<Q>): Q = (if (this < that) this else that) as Q
+infix fun <Q : Quan<Q>> Quan<Q>.max(that: Quan<Q>): Q = (if (this > that) this else that) as Q
+
+val <Q : Quan<Q>> Quan<Q>.abs get() = new(abs(siValue))
+val <Q : Quan<Q>> Quan<Q>.signum get() = siValue.sign
+val <Q : Quan<Q>> Quan<Q>.isNegative: Boolean get() = siValue < 0
+val <Q : Quan<Q>> Quan<Q>.isPositive: Boolean get() = siValue > 0
+
 private inline fun <reified Q : Quan<Q>> Q.eq(that: Any?) = when (that) {
-    is Q -> this.siValue == that.siValue
+    is Q -> this.fbvSiValue() == that.fbvSiValue()
     else -> false
 }
 

--- a/plugin/src/main/resources/info/kunalsheth/units/generated/QuanFBV.java
+++ b/plugin/src/main/resources/info/kunalsheth/units/generated/QuanFBV.java
@@ -1,0 +1,30 @@
+package info.kunalsheth.units.generated;
+
+import org.jetbrains.annotations.NotNull;
+
+// KT-26012 IDE IndexOutOfBoundsException for typealias with recursive type parameters
+public interface QuanFBV<
+        This extends QuanFBV<This, Integral, Derivative>,
+        Integral extends QuanFBV<Integral, ?, This>,
+        Derivative extends QuanFBV<Derivative, This, ?>
+        > extends Comparable<QuanFBV<This, ?, ?>> {
+
+    @NotNull
+    Double fbvSiValue();
+
+    @NotNull
+    String fbvAbrev();
+
+    @NotNull
+    This fbvNew(Double siValue);
+
+    @NotNull
+    Integral fbvTimes(@NotNull QuanFBV<L0M0T1I0Theta0N0J0, ?, ?> that);
+
+    @NotNull
+    Derivative fbvDiv(@NotNull QuanFBV<L0M0T1I0Theta0N0J0, ?, ?> that);
+
+    default int compareTo(@NotNull QuanFBV<This, ?, ?> other) {
+        return this.fbvSiValue().compareTo(other.fbvSiValue());
+    }
+}


### PR DESCRIPTION
This version probably won't crash the Kotlin plugin but prevents multiplatform use. (See [KT-26012](https://youtrack.jetbrains.com/issue/KT-26012))